### PR TITLE
Tweaked for Xcode 13.3.

### DIFF
--- a/Sources/Blessed/Authorization.swift
+++ b/Sources/Blessed/Authorization.swift
@@ -89,8 +89,8 @@ public class Authorization: Codable {
     /// Deserializes a `Data` instance into an `AuthorizationRef`.
     private static func deserialize(from serialization: Data) throws -> AuthorizationRef {
         // Convert data into authorization external form
-        var int8Array = [CChar](repeating: 0, count: kAuthorizationExternalFormLength)
-        for index in 0..<kAuthorizationExternalFormLength {
+        var int8Array = [CChar](repeating: 0, count: Int(kAuthorizationExternalFormLength))
+        for index in 0..<Int(kAuthorizationExternalFormLength) {
             int8Array[index] = CChar(bitPattern: serialization[index])
         }
         let bytes = (int8Array[0],  int8Array[1],  int8Array[2],  int8Array[3],

--- a/Tests/BlessedTests/BlessedTests.swift
+++ b/Tests/BlessedTests/BlessedTests.swift
@@ -2,10 +2,7 @@ import XCTest
 @testable import Blessed
 
 final class BlessedTests: XCTestCase {
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
-        XCTAssertEqual(Blessed().text, "Hello, World!")
+    func testAuthorizationInit() throws {
+        try XCTAssertNotNil(Authorization())
     }
 }


### PR DESCRIPTION
This addresses two issues revealed with Xcode 13.3:

- Implicit conversion from Int32
- Non-buildable Package.swift due to non-compilable tests.