### PR TITLE
Redesign of sandbox check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 xcuserdata/
 DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+*.xcscheme

--- a/README.md
+++ b/README.md
@@ -69,13 +69,11 @@ plug-in, which is not covered by this framework. See
 for more information.
 
 ## Sandboxing
-Most of this framework is *not* available to sandboxed apps because of privilege escalation.
+Most of this framework is *not* available to sandboxed processes because of privilege escalation.
 
 The exceptions to this are:
  - reading or existence checking a right definition in the Policy Database
  - enabling or disabling a login item
 
-If you need to determine at run time if your app is sandboxed, this framework exposes an extension on `NSApplication`:
-```swift
-let sandboxed = try NSApplication.shared.isSandboxed()
-```
+If you need to determine at run time if your process is sandboxed, this framework adds a property to `ProcessInfo`:
+`ProcessInfo.processInfo.isSandboxed`.

--- a/Sources/Blessed/Blessed.docc/Blessed.md
+++ b/Sources/Blessed/Blessed.docc/Blessed.md
@@ -80,17 +80,15 @@ underlying reference can be accessed via ``Authorization/authorizationRef``. How
 reference is bound to its containing `Authorization` instance.
 
 ## Sandboxing
-> Warning: Most of this framework is *not* available to sandboxed apps because of privilege escalation.
+> Warning: Most of this framework is *not* available to sandboxed processes because of privilege escalation.
 
 The exceptions to this are:
  - reading or existence checking a right definition in the Policy Database
  - enabling or disabling a login item
 
-If you need to determine at run time if your app is sandboxed, this framework exposes an extension on
-[`NSApplication`](https://developer.apple.com/documentation/appkit/nsapplication):
-```swift
-let sandboxed = try NSApplication.shared.isSandboxed()
-```
+If you need to determine at run time if your process is sandboxed, this framework adds a property to
+[`ProcessInfo`](https://developer.apple.com/documentation/foundation/processinfo):
+`ProcessInfo.processInfo.isSandboxed`.
 
 ## Topics
 ### Authorization

--- a/Sources/Blessed/ProcessInfo+Sandbox.swift
+++ b/Sources/Blessed/ProcessInfo+Sandbox.swift
@@ -1,15 +1,14 @@
 //
-//  NSApplication+Sandbox.swift
+//  ProcessInfo+Sandbox.swift
 //  Blessed
 //
 //  Created by Josh Kaplan on 2021-10-21
 //
 
 import Foundation
-import AppKit
 
-extension NSApplication {
-    /// A Boolean value indicating whether this app is sandboxed.
+extension ProcessInfo {
+    /// A Boolean value indicating whether this process is sandboxed.
     ///
     /// The value of this property is `true` if the
     /// [App Sandbox Entitlement](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_app-sandbox)

--- a/Tests/BlessedTests/BlessedTests.swift
+++ b/Tests/BlessedTests/BlessedTests.swift
@@ -1,6 +1,0 @@
-import XCTest
-@testable import Blessed
-
-final class BlessedTests: XCTestCase {
-    func testExample() throws { }
-}

--- a/Tests/BlessedTests/Sandbox Tests.swift
+++ b/Tests/BlessedTests/Sandbox Tests.swift
@@ -1,0 +1,16 @@
+//
+//  Sandbox Tests.swift
+//  Blessed
+//
+//  Created by Josh Kaplan on 2022-05-12
+//
+
+import XCTest
+import Blessed
+
+final class SandboxTests: XCTestCase {
+    
+    func testIsSandboxed() {
+        XCTAssertFalse(NSApplication.shared.isSandboxed)
+    }
+}

--- a/Tests/BlessedTests/Sandbox Tests.swift
+++ b/Tests/BlessedTests/Sandbox Tests.swift
@@ -11,6 +11,6 @@ import Blessed
 final class SandboxTests: XCTestCase {
     
     func testIsSandboxed() {
-        XCTAssertFalse(NSApplication.shared.isSandboxed)
+        XCTAssertFalse(ProcessInfo.processInfo.isSandboxed)
     }
 }


### PR DESCRIPTION
Instead of being a function on `NSApplication` it's now a property on `ProcessInfo` and the underly implementation is different.