### PR TITLE
Add assessment for blessing from a sandboxed program

### DIFF
--- a/Sources/Blessed/ProcessInfo+Sandbox.swift
+++ b/Sources/Blessed/ProcessInfo+Sandbox.swift
@@ -28,7 +28,7 @@ extension ProcessInfo {
             return false
         }
         
-        guard CFGetTypeID(entitlement) == CFBooleanGetTypeID(), let boolValue = (entitlement as? Bool) else {
+        guard let boolValue = entitlement as? Bool else {
             // The entitlement value must be a boolean value. If it's not, then it's presumbly not sandboxed.
             return false
         }


### PR DESCRIPTION
Hey Josh, it's been a while!

I had stopped working on my person project for a while, and I had given up on my goal to keep my main app sandboxed (while still having an unsandboxed XPC service to install an privileged helper, like Apple's [EvenBetterAuthorizationSample](https://developer.apple.com/library/archive/samplecode/EvenBetterAuthorizationSample/Listings/Read_Me_About_EvenBetterAuthorizationSample_txt.html)).

My XPC service was attempting to call `SMJobBless()`, always got denied, and I just couldn't figure out why. After coming back to with fresh eyes (for the third time!) and scouring the barrage of Console.app logs, I finally found this message:

> Sandbox denied authorizing right `com.apple.ServiceManagement.blesshelper` for authorization created by `/Users/Alex/MyApp.app/Contents/XPCServices/MyService.xpc` [49158] (engine 2754)	com.apple.Authorization

My XPC service was also sandboxed, unintentionally 🙃

For some reason I had `OTHER_CODE_SIGN_FLAGS = "--deep"` set on my main app's Xcode target, which made its XPC services inherit the `com.apple.security.app-sandbox` entitlement. Took ages, but I finally found the culprit.

To save others the frustration, I'm contributing back this new assessment, to detect this condition. You already had an `isSandboxed` extension (which isn't used elsewhere today), which worked perfectly here.